### PR TITLE
Run Playwright tests in CI and publish reports to GitHub Pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Download Playwright report
@@ -124,3 +125,37 @@ jobs:
             echo ""
             echo "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.target.outputs.dir }}/"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment preview link on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const url = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.target.outputs.dir }}/`;
+            const marker = "<!-- playwright-report-link -->";
+            const body = `${marker}\n### Playwright report\n\n${url}\n\nUpdated on every push to this PR.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const existing = comments.find((comment) => comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -77,7 +80,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -92,7 +95,7 @@ jobs:
 
     steps:
       - name: Download Playwright report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: playwright-report
           path: playwright-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,96 @@ jobs:
 
       - name: Run automated tests
         run: npm test
+
+  playwright:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install test dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        run: npm run test:smoke
+
+      - name: Publish summary
+        if: always()
+        run: |
+          node -e '
+            const fs = require("fs");
+            const resultsPath = "test-results/playwright/results.json";
+            const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+            if (!fs.existsSync(resultsPath)) {
+              fs.appendFileSync(summaryPath, "## Playwright smoke tests\n\nNo results file was produced.\n");
+              process.exit(0);
+            }
+            const { stats } = JSON.parse(fs.readFileSync(resultsPath, "utf8"));
+            const lines = [
+              "## Playwright smoke tests",
+              "",
+              "| Passed | Failed | Flaky | Skipped | Duration |",
+              "|---|---|---|---|---|",
+              "| " + stats.expected + " | " + stats.unexpected + " | " + stats.flaky + " | " + stats.skipped + " | " + (stats.duration / 1000).toFixed(1) + "s |",
+              "",
+              "Full HTML report with traces, videos, and screenshots is attached below as the `playwright-report` artifact."
+            ];
+            fs.appendFileSync(summaryPath, lines.join("\n") + "\n");
+          '
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: error
+
+  pages:
+    needs: playwright
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Playwright report
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+
+      - name: Determine deployment path
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "dir=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish report to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: playwright-report
+          destination_dir: ${{ steps.target.outputs.dir }}
+          keep_files: true
+
+      - name: Publish preview link
+        run: |
+          {
+            echo "## Playwright report (GitHub Pages)"
+            echo ""
+            echo "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ steps.target.outputs.dir }}/"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Generate a local coverage report with:
 npm run test:coverage
 ```
 
-The current automated suite covers pure allocation logic, panel lifecycle behavior, MyTE-like DOM scenarios for hour filling, weekly pattern application, WBS autocomplete and favorites, popup-based WBS extraction, and the background action routing logic. A separate Playwright smoke suite runs the real content script in Chromium against a fake MyTE page to verify panel opening, hour filling, and popup-based WBS loading end to end. The live MyTE site still requires a manual smoke test after major DOM automation changes.
+The current automated suite covers pure allocation logic, panel lifecycle behavior, MyTE-like DOM scenarios for hour filling, weekly pattern application, WBS autocomplete and favorites, popup-based WBS extraction, and the background action routing logic. A separate Playwright smoke suite runs the real content script in Chromium against a fake MyTE page to verify panel opening, hour filling, and popup-based WBS loading end to end. Both suites run automatically on every pull request (see [GitHub Actions](#github-actions) below). The live MyTE site still requires a manual smoke test after major DOM automation changes.
 
 ### Test Outputs
 
@@ -235,6 +235,18 @@ The current automated suite covers pure allocation logic, panel lifecycle behavi
 - Open the Playwright HTML report with `npm run test:smoke:report`.
 
 ### GitHub Actions
+
+The repository includes a workflow at `.github/workflows/test.yml`.
+
+- Runs on every pull request and on pushes to `main`
+- The `test` job runs the Vitest suite (`npm test`)
+- The `playwright` job installs Chromium, runs the Playwright smoke suite (`npm run test:smoke`), publishes a pass/fail summary table to the job's GitHub Actions summary page, and uploads the full HTML report (screenshots, videos, traces) as a downloadable `playwright-report` artifact on the workflow run — even when tests fail
+- The `pages` job publishes that same report to GitHub Pages, viewable directly in the browser (no download needed):
+  - Pushes to `main` publish to `https://gla-showcase.github.io/myte-autofill/main/`
+  - Each pull request publishes to its own persistent `https://gla-showcase.github.io/myte-autofill/pr-<number>/`, updated on every push to that PR
+  - The resulting URL is also printed on the job's GitHub Actions summary page
+  - Traces work directly from these pages (no `show-report` command needed) since they're served over `https://`
+- To inspect traces from a CI run locally instead: download the `playwright-report` artifact, unzip it, then run `npx playwright show-report path/to/playwright-report` (opening `index.html` directly won't work for traces, see below)
 
 The repository includes a workflow at `.github/workflows/package-chrome.yml`.
 

--- a/tests/playwright/smoke.spec.js
+++ b/tests/playwright/smoke.spec.js
@@ -6,39 +6,83 @@ import { readFile } from "node:fs/promises";
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(currentDir, "..", "..");
 const contentScriptPath = path.resolve(repoRoot, "content.js");
+const contentStylesPath = path.resolve(repoRoot, "styles.css");
 
 function buildHoursGridMarkup() {
-  let markup = '<div id="entryGridChargeCodeCell-1">WBS-1</div><div id="entryGridChargeCodeCell-2">WBS-2</div>';
+  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri"];
 
-  for (let dayIndex = 0; dayIndex < 5; dayIndex += 1) {
-    for (const rowIndex of [1, 2]) {
-      markup += `
-        <div id="entryGridHoursCell-${dayIndex}-${rowIndex}">
+  let headerCells = '<div class="myte-fake-cell myte-fake-corner">Charge Codes</div>';
+  dayLabels.forEach((label) => {
+    headerCells += `<div class="myte-fake-cell myte-fake-daycol">${label}</div>`;
+  });
+
+  let rowsMarkup = "";
+  for (const rowIndex of [1, 2]) {
+    let rowCells = `<div id="entryGridChargeCodeCell-${rowIndex}" class="myte-fake-cell myte-fake-chargecode">WBS-${rowIndex}</div>`;
+    for (let dayIndex = 0; dayIndex < 5; dayIndex += 1) {
+      rowCells += `
+        <div id="entryGridHoursCell-${dayIndex}-${rowIndex}" class="myte-fake-cell myte-fake-hours">
           <div contenteditable="true"></div>
         </div>
       `;
     }
+    rowsMarkup += `<div class="myte-fake-row">${rowCells}</div>`;
   }
 
-  return markup;
+  return `
+    <div class="myte-fake-table myte-fake-hours-table">
+      <div class="myte-fake-row myte-fake-header-row">${headerCells}</div>
+      ${rowsMarkup}
+    </div>
+  `;
 }
 
 function buildCategoryGridMarkup() {
-  let markup = "";
+  const categories = [
+    { prefix: "homeworking-full-day-", label: "HomeWorking Full Day", row: 2 },
+    { prefix: "office-client-", label: "Office / Client", row: 3 },
+    { prefix: "jai-respect-mon-repos-quotidien-", label: "J'ai respecté mon repos quotidien", row: 4 },
+    { prefix: "jai-respect-mon-repos-hebdomadaire-", label: "J'ai respecté mon repos hebdomadaire", row: 5 }
+  ];
 
+  let headerCells = '<div class="myte-fake-cell myte-fake-corner" style="grid-column:1;grid-row:1;">Categories</div>';
   for (let index = 0; index < 6; index += 1) {
-    const specialClass = index === 2 ? " special-cell" : "";
-    markup += `
-      <div id="timeCategoryCell-2-${index}" class="${specialClass.trim()}">
-        <input type="checkbox" id="homeworking-full-day-${index}">
-        <input type="checkbox" id="office-client-${index}">
-        <input type="checkbox" id="jai-respect-mon-repos-quotidien-${index}">
-        <input type="checkbox" id="jai-respect-mon-repos-hebdomadaire-${index}">
+    const isSpecial = index === 2;
+    headerCells += `<div class="myte-fake-cell myte-fake-daycol" style="grid-column:${index + 2};grid-row:1;">${isSpecial ? "Weekend" : "Day " + (index + 1)}</div>`;
+  }
+
+  let labelCells = "";
+  categories.forEach((cat) => {
+    labelCells += `<div class="myte-fake-cell myte-fake-catlabel" style="grid-column:1;grid-row:${cat.row};">${cat.label}</div>`;
+  });
+
+  let dayCells = "";
+  for (let index = 0; index < 6; index += 1) {
+    const isSpecial = index === 2;
+    const specialClass = isSpecial ? " special-cell" : "";
+    let checkboxCells = "";
+    categories.forEach((cat) => {
+      checkboxCells += `
+        <span class="myte-fake-checkbox-cell${isSpecial ? " myte-fake-checkbox-cell-special" : ""}" style="grid-column:${index + 2};grid-row:${cat.row};">
+          <input type="checkbox" id="${cat.prefix}${index}">
+        </span>
+      `;
+    });
+
+    dayCells += `
+      <div id="timeCategoryCell-2-${index}" class="myte-fake-catcolumn${specialClass}">
+        ${checkboxCells}
       </div>
     `;
   }
 
-  return markup;
+  return `
+    <div class="myte-fake-table myte-fake-category-table">
+      ${headerCells}
+      ${labelCells}
+      ${dayCells}
+    </div>
+  `;
 }
 
 function buildWbsPopupMarkup() {
@@ -46,6 +90,15 @@ function buildWbsPopupMarkup() {
     <button id="charge-code-1" class="assignment-container" type="button">Open WBS</button>
     <template id="wbs-popup-template">
       <div id="My_TE_Time_MenuChargeCodes">
+        <div class="ag-header-row">
+          <div class="ag-header-cell ag-header-cell-marker"></div>
+          <div class="ag-header-cell">Type</div>
+          <div class="ag-header-cell">Sub-type</div>
+          <div class="ag-header-cell">Client</div>
+          <div class="ag-header-cell">Country/Region</div>
+          <div class="ag-header-cell">Description</div>
+          <div class="ag-header-cell">Code</div>
+        </div>
         <div class="ag-center-cols-viewport">
           <div role="row" row-id="1">
             <div class="ag-cell-value"></div>
@@ -88,14 +141,260 @@ function buildFakeMytePage() {
         <meta charset="utf-8">
         <title>Fake MyTE</title>
         <style>
-          body { font-family: Arial, sans-serif; }
-          .special-cell { outline: 1px dashed #999; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+            background: #f2f2f5;
+            color: #222;
+          }
+
+          /* ---- Top bar mimicking the real MyTE nav ---- */
+          .myte-fake-topbar {
+            background: #ffffff;
+            border-bottom: 3px solid #a100ff;
+            padding: 0 20px;
+          }
+          .myte-fake-tabs {
+            display: flex;
+            gap: 24px;
+          }
+          .myte-fake-tab {
+            padding: 14px 2px;
+            font-size: 13px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: #666;
+            border-bottom: 3px solid transparent;
+            margin-bottom: -3px;
+          }
+          .myte-fake-tab-active {
+            color: #a100ff;
+            border-bottom-color: #a100ff;
+          }
+
+          .myte-fake-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: #ffffff;
+            padding: 10px 20px;
+            border-bottom: 1px solid #e0e0e5;
+          }
+          .myte-fake-toolbar-actions {
+            display: flex;
+            gap: 18px;
+            font-size: 12px;
+            color: #555;
+          }
+          .myte-fake-toolbar-status {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+          }
+          .myte-fake-status-draft {
+            font-size: 12px;
+            color: #888;
+          }
+          .myte-fake-submit-btn {
+            background: #a100ff;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            padding: 8px 18px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+          }
+
+          .myte-fake-content {
+            padding: 20px;
+          }
+
+          /* ---- Shared table look ---- */
+          .myte-fake-table {
+            display: grid;
+            background: #fff;
+            border: 1px solid #d8d8e0;
+            border-radius: 6px;
+            overflow: hidden;
+            font-size: 13px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+          }
+          .myte-fake-cell {
+            padding: 8px 10px;
+            border-bottom: 1px solid #ececf2;
+            border-right: 1px solid #ececf2;
+            display: flex;
+            align-items: center;
+            background: #fff;
+          }
+          .myte-fake-corner,
+          .myte-fake-daycol {
+            background: #f4edfb;
+            font-weight: 600;
+            color: #5a2a86;
+            border-bottom: 2px solid #a100ff;
+          }
+          .myte-fake-chargecode {
+            font-weight: 500;
+            color: #222;
+          }
+
+          /* ---- Hours table ---- */
+          .myte-fake-hours-table {
+            grid-template-columns: 220px repeat(5, 90px);
+            margin-bottom: 20px;
+          }
+          .myte-fake-hours-table .myte-fake-row { display: contents; }
+          .myte-fake-hours [contenteditable="true"] {
+            width: 100%;
+            min-height: 20px;
+            outline: none;
+            text-align: center;
+            border-radius: 3px;
+          }
+          .myte-fake-hours [contenteditable="true"]:focus {
+            background: #f4edfb;
+            box-shadow: 0 0 0 2px rgba(161, 0, 255, 0.25);
+          }
+
+          /* ---- Category / checkbox table ---- */
+          .myte-fake-category-table {
+            grid-template-columns: 240px repeat(6, 76px);
+            grid-auto-rows: 34px;
+          }
+          .myte-fake-catcolumn { display: contents; }
+          .myte-fake-catlabel {
+            color: #444;
+          }
+          .myte-fake-checkbox-cell {
+            grid-row: span 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-bottom: 1px solid #ececf2;
+            border-right: 1px solid #ececf2;
+            background: #fff;
+          }
+          .myte-fake-checkbox-cell input[type="checkbox"] {
+            width: 15px;
+            height: 15px;
+            accent-color: #a100ff;
+            cursor: pointer;
+          }
+          .myte-fake-checkbox-cell-special {
+            background: #f0f0f3;
+          }
+          .myte-fake-checkbox-cell-special input {
+            opacity: 0.35;
+          }
+
+          /* ---- WBS popup (ag-grid style) ---- */
+          .assignment-container {
+            border: 1px solid #d0d0d8;
+            background: #fff;
+            border-radius: 4px;
+            padding: 4px 10px;
+            font-size: 12px;
+            color: #5a2a86;
+            cursor: pointer;
+          }
+          .assignment-container:hover { background: #f4edfb; }
+
+          #My_TE_Time_MenuChargeCodes {
+            position: absolute;
+            width: 680px;
+            max-width: 90vw;
+            margin-top: 6px;
+            background: #fff;
+            border: 1px solid #d0d0d8;
+            border-radius: 6px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+            overflow: hidden;
+            font-size: 12px;
+            z-index: 10000;
+          }
+          .ag-header-row {
+            display: flex;
+            background: #f4edfb;
+            font-weight: 600;
+            color: #5a2a86;
+            border-bottom: 2px solid #a100ff;
+          }
+          .ag-header-cell {
+            flex: 1 1 0;
+            padding: 8px 10px;
+          }
+          .ag-header-cell-marker {
+            flex: 0 0 0;
+            width: 0;
+            padding: 0;
+          }
+          .ag-center-cols-viewport {
+            max-height: 220px;
+            overflow-y: auto;
+          }
+          [role="row"] {
+            display: flex;
+            border-bottom: 1px solid #ececf2;
+            cursor: pointer;
+          }
+          [role="row"]:hover {
+            background: #f8f5fc;
+          }
+          [role="row"] [col-id] {
+            flex: 1 1 0;
+            padding: 8px 10px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+          .ag-cell-value {
+            flex: 0 0 0;
+            width: 0;
+            padding: 0;
+            overflow: hidden;
+          }
+          [role="row"]:has(.error-cell) {
+            background: rgba(217, 45, 81, 0.06);
+          }
+          [role="row"]:has(.error-cell) [col-id] {
+            color: #d92d51;
+          }
         </style>
       </head>
       <body>
-        ${buildHoursGridMarkup()}
-        ${buildCategoryGridMarkup()}
-        ${buildWbsPopupMarkup()}
+        <div class="myte-fake-app">
+          <div class="myte-fake-topbar">
+            <div class="myte-fake-tabs">
+              <span class="myte-fake-tab myte-fake-tab-active">TIME</span>
+              <span class="myte-fake-tab">EXPENSES</span>
+              <span class="myte-fake-tab">LOCATIONS</span>
+              <span class="myte-fake-tab">CHARGE CODES</span>
+              <span class="myte-fake-tab">ADJUSTMENTS</span>
+              <span class="myte-fake-tab">SUMMARY</span>
+              <span class="myte-fake-tab">PREFERENCES</span>
+            </div>
+          </div>
+          <div class="myte-fake-toolbar">
+            <div class="myte-fake-toolbar-actions">
+              <span>SAVE</span>
+              <span>DELETE</span>
+              <span>SET TEMPLATE</span>
+              <span>HELP</span>
+            </div>
+            <div class="myte-fake-toolbar-status">
+              <span class="myte-fake-status-draft">Draft</span>
+              <button class="myte-fake-submit-btn" type="button">Submit</button>
+            </div>
+          </div>
+          <div class="myte-fake-content">
+            ${buildHoursGridMarkup()}
+            ${buildCategoryGridMarkup()}
+            ${buildWbsPopupMarkup()}
+          </div>
+        </div>
         <script>
           const opener = document.getElementById("charge-code-1");
           const popupTemplate = document.getElementById("wbs-popup-template");
@@ -173,6 +472,9 @@ async function installExtensionHarness(page, storageData) {
       }
     };
   }, storageData);
+  // manifest.json declares styles.css as a content_scripts CSS file, which Chrome
+  // injects automatically into the page. Replicate that here so the panel is styled.
+  await page.addStyleTag({ path: contentStylesPath });
   await page.addScriptTag({ path: contentScriptPath });
 }
 


### PR DESCRIPTION
## Summary
- Fixed the Playwright smoke harness to inject `styles.css` alongside `content.js` (previously the fake MyTE page and panel screenshots rendered with no styling at all), and restyled the fake MyTE page to visually resemble the real timesheet grid (tabs, charge-code table, category checkboxes, ag-grid-style WBS popup).
- Added a `playwright` CI job that runs the smoke suite on every PR/push to `main`, publishes a pass/fail summary to the job's GitHub Actions summary, and uploads the full HTML report (screenshots, videos, traces) as a workflow artifact — even when tests fail.
- Added a `pages` CI job that publishes that report to GitHub Pages: pushes to `main` go to `/main/`, and each PR gets its own persistent `/pr-<number>/` URL updated on every push, so a reviewer can open traces directly in the browser without downloading anything.
- Documented all of the above in the README's testing/CI sections.

## Test plan
- [x] `npm test` (Vitest) passes locally
- [x] `npm run test:smoke` (Playwright) passes locally with styled screenshots
- [x] Workflow YAML validated with `js-yaml`
- [ ] After merge: confirm the `playwright` and `pages` jobs run successfully on this PR, then enable GitHub Pages in repo Settings → Pages → Source → Deploy from branch → `gh-pages` → `/` (the branch is created automatically by the first successful `pages` job run)