### PR TITLE
Fix GitHub Pages root URL 404

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,30 @@ jobs:
           destination_dir: ${{ steps.target.outputs.dir }}
           keep_files: true
 
+      - name: Prepare root index redirect
+        run: |
+          mkdir -p gh-pages-root
+          cat > gh-pages-root/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0; url=./main/">
+              <title>MyTE Autofill - Playwright reports</title>
+            </head>
+            <body>
+              <p>Redirecting to the latest <a href="./main/">main branch Playwright report</a>...</p>
+            </body>
+          </html>
+          HTML
+
+      - name: Publish root index to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: gh-pages-root
+          keep_files: true
+
       - name: Publish preview link
         run: |
           {


### PR DESCRIPTION
## Summary
- The repo's Environments → github-pages deployment link always points to the site root (`https://gla-showcase.github.io/myte-autofill/`), but the `pages` job only ever publishes to `/main/` and `/pr-<number>/` subfolders, so the root URL 404ed.
- Adds a small `index.html` at the gh-pages branch root that redirects to `/main/`, published as an extra step after the report itself, with `keep_files: true` so it doesn't disturb the existing per-PR/main report folders.

## Test plan
- [x] Workflow YAML validated with `js-yaml`
- [x] Heredoc script simulated locally, produces the expected HTML
- [ ] After merge: confirm `https://gla-showcase.github.io/myte-autofill/` redirects to `/main/` instead of 404ing