### PR TITLE
Auto-tag and publish a release when manifest.json version bumps

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,65 @@
+name: Auto Tag Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - manifest.json
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Read manifest version
+        id: version
+        run: |
+          version=$(node -p "require('./manifest.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check token configuration
+        id: token
+        run: |
+          if [ -n "${{ secrets.COPILOT_AGENT_TOKEN }}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push release tag
+        if: steps.check.outputs.exists != 'true' && steps.token.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_AGENT_TOKEN }}
+          TAG_NAME: v${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG_NAME"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "$TAG_NAME"
+
+      - name: Warn about missing token
+        if: steps.check.outputs.exists != 'true' && steps.token.outputs.configured != 'true'
+        run: |
+          echo "::warning::manifest.json version ${{ steps.version.outputs.version }} has no matching tag, but COPILOT_AGENT_TOKEN is not configured. A plain GITHUB_TOKEN push cannot be used here because tag pushes made with the default token do not trigger other workflows (release-chrome.yml would never run). Configure COPILOT_AGENT_TOKEN or push the tag manually: git tag v${{ steps.version.outputs.version }} && git push origin v${{ steps.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ The repository also includes a release workflow at `.github/workflows/release-ch
 - Push a tag like `v1.2.3`
 - The workflow validates that the tag version matches `manifest.json`, builds the package, creates a GitHub Release, and attaches the zip, contents manifest, and generated release notes
 
+Tags don't have to be pushed by hand: `.github/workflows/auto-tag-release.yml` runs on every push to `main` that changes `manifest.json`. If the manifest's version doesn't already have a matching `vX.Y.Z` tag, it creates and pushes one, which triggers `release-chrome.yml` automatically. It authenticates with the `COPILOT_AGENT_TOKEN` secret rather than the default `GITHUB_TOKEN`, because tag pushes made with the default token don't trigger other workflows.
+
 The repository also includes Copilot bug automation workflows:
 
 - `.github/workflows/copilot-bug-intake.yml`: validates new bug issues, applies agent labels, and assigns valid issues to GitHub Copilot coding agent


### PR DESCRIPTION
## Summary
- `release-chrome.yml` only triggers on a pushed `vX.Y.Z` tag, so merging a version-bump PR into `main` (like #17) previously required someone to manually push a matching tag afterward to actually publish a release.
- Adds `.github/workflows/auto-tag-release.yml`: on every push to `main` that touches `manifest.json`, it reads the version, checks whether a matching tag already exists, and creates + pushes it if not.
- Uses the `COPILOT_AGENT_TOKEN` secret (not the default `GITHUB_TOKEN`) for the tag push, since GitHub explicitly excludes `GITHUB_TOKEN`-authenticated pushes from triggering other workflow runs — pushing the tag with the default token would silently never kick off `release-chrome.yml`.
- Documents the new workflow in the README's GitHub Actions section.

## Test plan
- [x] Workflow YAML validated with `js-yaml`
- [x] Version-read and tag-existence-check logic simulated locally against the real manifest.json and git tags
- [ ] After merge: confirm the next version-bump merge to `main` (e.g. PR #17 bumping to 1.5.0) automatically creates tag `v1.5.0` and triggers `release-chrome.yml`