### PR TITLE
Rename GPT-era fill logic identifiers, bump to 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Autofill Accenture MyTE timesheets with multi-WBS allocations and homeworking/of
 ![Edge Add-ons](https://img.shields.io/badge/Edge_Add--ons-Pending-blue?logo=microsoftedge&logoColor=white)
 ![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)
 ![Status](https://img.shields.io/badge/Status-Active-brightgreen)
-![Version](https://img.shields.io/badge/Version-1.4.1-purple)
+![Version](https://img.shields.io/badge/Version-1.4.2-purple)
 
 <img width="1400" height="933" alt="marquee-promo-tile-1400x560 png" src="https://github.com/user-attachments/assets/de0b8adc-c3d2-4f52-be44-0cfa90b37de0" />
 
@@ -344,3 +344,4 @@ Pull requests should preserve the extension’s **single purpose**:
 ## 📄 License
 
 MIT License.
+

--- a/content.js
+++ b/content.js
@@ -832,7 +832,7 @@ async function ensureWbsInRowByCode(code, rowNumber, fallbackRowIndex = null) {
 /***********************
  * HOURS FILLING LOGIC
  ***********************/
-const MYTE_GPT_FILL_DEFAULTS = {
+const MYTE_GRID_FILL_DEFAULTS = {
   hours: "7.7",
   delayMs: 12,
   skipFilledCells: true,
@@ -1134,8 +1134,8 @@ function collectTargetCellsForSelections(gridRoot, resolvedSelections, options) 
     : mergeTargetCells(targetCells, fallbackCells);
 }
 
-async function fillTimesheetCellsWithGptLogic(overrides = {}) {
-  const options = { ...MYTE_GPT_FILL_DEFAULTS, ...overrides };
+async function fillTimesheetGridCells(overrides = {}) {
+  const options = { ...MYTE_GRID_FILL_DEFAULTS, ...overrides };
   options.hours = formatHoursForInput(options.hours);
   const gridRoot = getGridRoot();
 
@@ -1242,7 +1242,7 @@ async function fillTimesheetWithConfig(config) {
 
     let fillResult;
     try {
-      fillResult = await fillTimesheetCellsWithGptLogic({
+      fillResult = await fillTimesheetGridCells({
         hours: formatHoursForInput(hours),
         wbsSelections: [wbsSelection],
         resolvedSelections,
@@ -2503,7 +2503,7 @@ function exposeTestApi() {
     getWorkingDayIndices,
     computeDailyHoursPerWbs,
     mergeTargetCells,
-    fillTimesheetCellsWithGptLogic,
+    fillTimesheetGridCells,
     fillTimesheetWithConfig,
     applyWeeklyPatternAndRest,
     applyThemeClass,

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "MyTE Autofill Helper",
   "short_name": "MyTE Autofill",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Autofill Accenture MyTE timesheets with multi-WBS allocations and homeworking/office patterns.",
 
   "homepage_url": "https://chromewebstore.google.com/detail/myte-autofill-helper/dfpohbobkklfchohecohngodhagffhib",
@@ -50,6 +50,7 @@
     }
   ]
 }
+
 
 
 

--- a/tests/content.scenarios.test.js
+++ b/tests/content.scenarios.test.js
@@ -380,7 +380,7 @@ describe("content.js scenarios", () => {
     const { api } = await loadContentScript();
     buildHoursGrid();
 
-    const result = await api.fillTimesheetCellsWithGptLogic({
+    const result = await api.fillTimesheetGridCells({
       hours: "7,7",
       resolvedSelections: [{ rowNumber: 1, code: "WBS-1", rowIndex: 1 }],
       wbsSelections: [{ rowNumber: 1, code: "WBS-1" }]
@@ -526,7 +526,7 @@ describe("content.js scenarios", () => {
     chargeCell.textContent = "WBS-1";
     document.body.appendChild(chargeCell);
 
-    const result = await api.fillTimesheetCellsWithGptLogic({
+    const result = await api.fillTimesheetGridCells({
       hours: "7.7",
       resolvedSelections: [{ rowNumber: 1, code: "WBS-1", rowIndex: 1 }],
       wbsSelections: [{ rowNumber: 1, code: "WBS-1" }]
@@ -616,7 +616,7 @@ describe("content.js scenarios", () => {
     chargeCell.textContent = "WBS-1";
     document.body.appendChild(chargeCell);
 
-    const result = await api.fillTimesheetCellsWithGptLogic({
+    const result = await api.fillTimesheetGridCells({
       hours: "7.7",
       resolvedSelections: [{ rowNumber: 1, code: "WBS-1", rowIndex: 1 }],
       wbsSelections: [{ rowNumber: 1, code: "WBS-1" }]
@@ -704,7 +704,7 @@ describe("content.js scenarios", () => {
     chargeCell.textContent = "WBS-1";
     document.body.appendChild(chargeCell);
 
-    const result = await api.fillTimesheetCellsWithGptLogic({
+    const result = await api.fillTimesheetGridCells({
       hours: "7.7",
       resolvedSelections: [{ rowNumber: 1, code: "WBS-1", rowIndex: 1 }],
       wbsSelections: [{ rowNumber: 1, code: "WBS-1" }]
@@ -805,7 +805,7 @@ describe("content.js scenarios", () => {
 
     document.getElementById("entryGridHoursCell-0-1").click();
 
-    const result = await api.fillTimesheetCellsWithGptLogic({
+    const result = await api.fillTimesheetGridCells({
       hours: "7.7",
       resolvedSelections: [{ rowNumber: 1, code: "WBS-1", rowIndex: 1 }],
       wbsSelections: [{ rowNumber: 1, code: "WBS-1" }]


### PR DESCRIPTION
## Summary
- `fillTimesheetCellsWithGptLogic` and `MYTE_GPT_FILL_DEFAULTS` were named during earlier trial-and-error across several models while the grid-cell fill logic was unstable. Now that it's stable, renamed to `fillTimesheetGridCells` and `MYTE_GRID_FILL_DEFAULTS` to describe what the code does rather than its iteration history.
- Naming-only change, no behavior change.
- Patch bump to 1.4.2.

## Test plan
- [x] `npm test` (34/34)
- [x] `npm run test:smoke` (6/6)
- [x] `grep -rn "Gpt\|GPT" content.js tests/` returns no matches