### PR TITLE
Fix auto-tag-release credentials

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Read manifest version
         id: version


### PR DESCRIPTION
## Summary
The first real run of auto-tag-release.yml (triggered by PR #20's merge) failed: `Permission to gla-showcase/myte-autofill.git denied to github-actions[bot]`. `actions/checkout` persists the default `GITHUB_TOKEN` as a git credential (an `http.extraheader` config) by default, which took precedence over the `COPILOT_AGENT_TOKEN` PAT embedded in the remote URL for the push step. Sets `persist-credentials: false` on checkout so the PAT is the only credential in play.

v1.4.2's tag was pushed manually to unblock that release; this fixes the automation for future version bumps.

## Test plan
- [x] Manually pushing the tag with proper credentials confirmed `release-chrome.yml` itself works correctly
- [ ] After merge: confirm the next version-bump merge to `main` (PR #17 → 1.5.0) auto-tags and releases without manual intervention